### PR TITLE
Fix audio flow and persist call history

### DIFF
--- a/api.py
+++ b/api.py
@@ -60,6 +60,7 @@ def make_call_sync(request: CallRequest):
         target_number=request.target_number,
         initial_message=request.initial_message,
         call_context=request.call_context,
+        conversation_manager=conversation_manager,
     )
     
     # Get the conversation ID before starting
@@ -109,6 +110,7 @@ async def make_call_async(request: CallRequest, background_tasks: BackgroundTask
         target_number=request.target_number,
         initial_message=request.initial_message,
         call_context=request.call_context,
+        conversation_manager=conversation_manager,
     )
     
     background_tasks.add_task(run_call, adapter)

--- a/src/ai/live_client.py
+++ b/src/ai/live_client.py
@@ -36,7 +36,13 @@ INITIAL_WAIT_SECONDS = 12  # Wait up to 12 seconds for user to speak first
 class AudioBridge:
     """Bridges SIP audio with Gemini Live API for real-time conversation with function calling."""
 
-    def __init__(self, phone_number: Optional[str] = None, call_context: Optional[str] = None, voip_adapter=None):
+    def __init__(
+        self,
+        phone_number: Optional[str] = None,
+        call_context: Optional[str] = None,
+        voip_adapter=None,
+        conversation_manager: Optional[ConversationManager] = None,
+    ):
         """Initialize audio bridge."""
         self.phone_number = phone_number
         self.call_context = call_context
@@ -50,8 +56,8 @@ class AudioBridge:
             api_key=self.api_key,
         )
         
-        # Conversation manager
-        self.conversation_manager = ConversationManager()
+        # Conversation manager - allow external instance for shared state
+        self.conversation_manager = conversation_manager or ConversationManager()
         self.conversation_id: Optional[str] = None
         
         # Audio queues
@@ -331,9 +337,10 @@ CONVERSATION GUIDELINES:
         silence_duration = 0
         last_was_speech = False
         consecutive_silence_chunks = 0
-        
+
         # Track when user stops speaking to add natural pause
         user_stopped_speaking_time = None
+        end_of_turn_sent = False
         
         while self.running:
             try:
@@ -390,6 +397,18 @@ CONVERSATION GUIDELINES:
                     
                     # Send audio to AI
                     await self.session.send(input=audio_msg)
+
+                    # If we've detected the user stopped speaking for >0.6s,
+                    # explicitly end the turn so the AI can respond naturally
+                    if (
+                        user_stopped_speaking_time
+                        and not end_of_turn_sent
+                        and (time.time() - user_stopped_speaking_time) > 0.6
+                    ):
+                        await self.session.send(end_of_turn=True)
+                        end_of_turn_sent = True
+                    elif is_speech:
+                        end_of_turn_sent = False
                 else:
                     logger.warning("⚠️  No session available for sending audio")
             except Exception as e:

--- a/src/voip/gemini_voip_adapter.py
+++ b/src/voip/gemini_voip_adapter.py
@@ -8,6 +8,8 @@ import audioop
 import logging
 from typing import Optional
 
+from ai.conversation import ConversationManager
+
 from ai.live_client import AudioBridge  # your existing Gemini Live client
 
 logger = logging.getLogger(__name__)
@@ -70,6 +72,7 @@ class GeminiVoipAdapter:
         initial_message: Optional[str] = None,
         max_session_minutes: int = 14,
         call_context: Optional[str] = None,
+        conversation_manager: Optional[ConversationManager] = None,
     ):
         self.voip = voip_client
         self.target = target_number
@@ -87,7 +90,12 @@ class GeminiVoipAdapter:
         self._fifo_thread: Optional[threading.Thread] = None
         self._loop_ready = threading.Event()  # Signal when event loop is ready
 
-        self._bridge = AudioBridge(phone_number=self.target, call_context=self.call_context, voip_adapter=self)
+        self._bridge = AudioBridge(
+            phone_number=self.target,
+            call_context=self.call_context,
+            voip_adapter=self,
+            conversation_manager=conversation_manager,
+        )
 
     # ---------- Event loop (Gemini) ----------
 


### PR DESCRIPTION
## Summary
- share the conversation manager across API and audio bridge
- send explicit end-of-turn signal after user stops talking
- persist completed conversations to `data/conversations.json`

## Testing
- `pytest -q`
- `python -m py_compile api.py src/ai/*.py src/voip/*.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688d1443bb2c83209626c2d9f6d28add